### PR TITLE
Fix composer installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Create a composer.json in your projects root-directory::
 
     {
         "require": {
-            "mheap/Silex-Markdown": "*"
+            "mheap/silex-markdown": "dev-master"
         }
     }
 


### PR DESCRIPTION
With previous instructions, installation was impossible due to following error message:

> The requested package mheap/Silex-Markdown could not be found in any version, there may be a typo in the package name.
